### PR TITLE
Export helper functions

### DIFF
--- a/src/node_footer.js
+++ b/src/node_footer.js
@@ -28,6 +28,7 @@ exports.httpClient = httpClient;
 exports.inprocClient = inprocClient;
 exports.Client = Client;
 exports.Server = Server;
+exports.Contract = Contract;
 exports.JSON_stringify = JSON_stringify;
 exports.errResp = errResp;
 exports.parseResponse = parseResponse;


### PR DESCRIPTION
Motivations:
- I'd like access to these helper functions in my custom transport.
- I'd like to be able to use the Contract validation stuff outside of a Barrister Server context (for instance, for the response to a non JSON-RPC 2.0 request).
